### PR TITLE
Added image management to the collection category UI

### DIFF
--- a/src/views/collections/categories/Create.vue
+++ b/src/views/collections/categories/Create.vue
@@ -23,11 +23,11 @@
             :errors="form.$errors"
             :name.sync="form.name"
             :intro.sync="form.intro"
-            :icon.sync="form.icon"
             :order.sync="form.order"
             :enabled.sync="form.enabled"
             :sideboxes.sync="form.sideboxes"
             :category_taxonomies.sync="form.category_taxonomies"
+            @update:image_file_id="form.image_file_id = $event"
             @clear="form.$errors.clear($event)"
           />
 
@@ -54,7 +54,7 @@ export default {
       form: new Form({
         name: "",
         intro: "",
-        icon: "",
+        image_file_id: null,
         order: 1,
         enabled: true,
         sideboxes: [],

--- a/src/views/collections/categories/Edit.vue
+++ b/src/views/collections/categories/Edit.vue
@@ -27,13 +27,14 @@
 
             <collection-form
               :errors="form.$errors"
+              :id="collection.id"
               :name.sync="form.name"
               :intro.sync="form.intro"
-              :icon.sync="form.icon"
               :order.sync="form.order"
               :enabled.sync="form.enabled"
               :sideboxes.sync="form.sideboxes"
               :category_taxonomies.sync="form.category_taxonomies"
+              @update:image_file_id="form.image_file_id = $event"
               @clear="form.$errors.clear($event)"
             />
 
@@ -85,7 +86,7 @@ export default {
       this.form = new Form({
         name: this.collection.name,
         intro: this.collection.intro,
-        icon: this.collection.icon,
+        image_file_id: null,
         order: this.collection.order,
         enabled: this.collection.enabled,
         sideboxes: this.collection.sideboxes,

--- a/src/views/collections/categories/forms/CollectionForm.vue
+++ b/src/views/collections/categories/forms/CollectionForm.vue
@@ -22,29 +22,25 @@
       :error="errors.get('intro')"
     />
 
-    <ck-select-input
-      :value="icon"
-      @input="onInput('icon', $event)"
-      id="icon"
-      label="Icon"
-      :error="errors.get('icon')"
-      has-icons
+    <ck-image-input
+      @input="onInput('image_file_id', $event.file_id)"
+      id="image"
+      label="Category image"
+      accept="image/x-svg"
+      :existing-url="
+        id
+          ? apiUrl(`/collections/categories/${id}/image.svg?v=${now}`)
+          : undefined
+      "
     >
-      <gov-hint slot="hint" for="icon">
-        If you're having trouble viewing the icons, refer to the
-        <gov-link href="https://fontawesome.com/icons" target="_blank"
-          >Font Awesome website</gov-link
-        >
-        (the font library used).
-      </gov-hint>
-      <option
-        v-for="(option, key) in icons"
-        :key="key"
-        :value="option.value"
-        :disabled="option.disabled"
-        v-html="option.text"
-      />
-    </ck-select-input>
+      <template slot="after-error-message">
+        <gov-error-message
+          v-if="errors.get('image_file_id')"
+          v-text="errors.get('image_file_id')"
+          for="image"
+        />
+      </template>
+    </ck-image-input>
 
     <collection-enabled-input
       :value="enabled"
@@ -82,26 +78,32 @@
 </template>
 
 <script>
-import icons from "@/storage/icons";
+import CkImageInput from "@/components/Ck/CkImageInput";
 import CkTaxonomyInput from "@/components/Ck/CkTaxonomyInput";
 import CkSideboxesInput from "@/views/collections/inputs/SideboxesInput";
 import CollectionEnabledInput from "@/views/collections/inputs/CollectionEnabledInput";
 
 export default {
   name: "CollectionForm",
-  components: { CollectionEnabledInput, CkTaxonomyInput, CkSideboxesInput },
+  components: {
+    CollectionEnabledInput,
+    CkTaxonomyInput,
+    CkSideboxesInput,
+    CkImageInput
+  },
   props: {
     errors: {
       required: true,
       type: Object
     },
+    id: {
+      required: false,
+      type: String
+    },
     name: {
       required: true
     },
     intro: {
-      required: true
-    },
-    icon: {
       required: true
     },
     order: {
@@ -116,14 +118,6 @@ export default {
     category_taxonomies: {
       required: true
     }
-  },
-  data() {
-    return {
-      icons: [
-        { text: "Please select...", value: null, disabled: true },
-        ...icons
-      ]
-    };
   },
   methods: {
     onInput(field, value) {


### PR DESCRIPTION
### Summary
https://app.shortcut.com/ayup-digital-ltd/story/329/update-collections-to-accept-image-instead-of-icon

Removed icon management from Collection Category UI
Added image management to Collection Category UI

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
