### PR TITLE
Add image file id to collection when updating

### DIFF
--- a/src/views/collections/categories/Edit.vue
+++ b/src/views/collections/categories/Edit.vue
@@ -86,7 +86,7 @@ export default {
       this.form = new Form({
         name: this.collection.name,
         intro: this.collection.intro,
-        image_file_id: null,
+        image_file_id: this.collection.image_file_id,
         order: this.collection.order,
         enabled: this.collection.enabled,
         sideboxes: this.collection.sideboxes,


### PR DESCRIPTION
### Summary
https://app.shortcut.com/ayup-digital-ltd/story/1835/bug-re-ordering-of-collections-returns-an-error

Alter the collection category edit view to pass the existing image file id 

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
NA

### Notes
NA
