### PR TITLE
Added events to org admin dashboard. Org select defaults to null to f…

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -60,7 +60,7 @@
           <gov-section-break size="m" />
         </gov-grid-column>
 
-        <gov-grid-column width="one-half" v-if="auth.isGlobalAdmin">
+        <gov-grid-column width="one-half" v-if="auth.isOrganisationAdmin">
           <gov-heading size="l">Events</gov-heading>
           <gov-body>Add or edit events on Hounslow Connect.</gov-body>
           <gov-button start :to="{ name: 'events-index' }">

--- a/src/views/events/Create.vue
+++ b/src/views/events/Create.vue
@@ -120,7 +120,7 @@ export default {
         { id: "taxonomies", heading: "Taxonomies", active: false }
       ],
 
-      organisations: [{ text: "Please select", value: null, disabled: true }],
+      organisations: [{ text: "Please select", value: null }],
       loading: false
     };
   },

--- a/src/views/events/show/EventDetails.vue
+++ b/src/views/events/show/EventDetails.vue
@@ -4,6 +4,10 @@
     <gov-table>
       <template slot="body">
         <gov-table-row>
+          <gov-table-header scope="row" top>Organisation</gov-table-header>
+          <gov-table-cell>{{ event.organisation.name }}</gov-table-cell>
+        </gov-table-row>
+        <gov-table-row>
           <gov-table-header scope="row" top>Title</gov-table-header>
           <gov-table-cell>{{ event.title }}</gov-table-cell>
         </gov-table-row>


### PR DESCRIPTION
### Summary
https://app.shortcut.com/ayup-digital-ltd/story/2033/uat-feedback-bugs

- Add select call to action to org admin dashboard
- Remove disabled property from org select on event create form. This was preventing the select from defaulting to the null option ('Please select'), and instead defaulting to an organisation. As the organisation id is set on the select event this meant that a select event was not possible with only 1 organisation, so no id was set.

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
