### PR TITLE
Hounslow sc 2081 bug events are viewable as an org admin from

### DIFF
--- a/src/views/events/Index.vue
+++ b/src/views/events/Index.vue
@@ -96,7 +96,10 @@ export default {
   },
   computed: {
     params() {
-      let params = {};
+      let params = {
+        include: "organisation",
+        "filter[has_permission]": true
+      };
 
       if (this.filters.organisation !== "") {
         params["filter[organisation]"] = this.filters.organisation;


### PR DESCRIPTION
### Summary
https://app.shortcut.com/ayup-digital-ltd/story/2081/bug-events-are-viewable-as-an-org-admin-from-another-organisation

- Added has_permission filter when fetching all events for organisation event index

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
