### PR TITLE
Hide intro text after event create

### DIFF
--- a/src/views/events/Create.vue
+++ b/src/views/events/Create.vue
@@ -8,32 +8,31 @@
         <gov-grid-column width="full">
           <gov-heading size="xl">Events</gov-heading>
 
-          <template v-if="!auth.isGlobalAdmin">
-            <gov-body class="govuk-!-font-weight-bold">
-              Please review the process below on how to create an event.
-            </gov-body>
-
-            <gov-list bullet>
-              <li>To create an event, fill in the form below.</li>
-              <li>
-                The event won't be visible until an admin has reviewed it.
-              </li>
-              <li>
-                If there are any issues upon review, an admin will get directly
-                in touch with you.
-              </li>
-            </gov-list>
-
-            <div v-if="updateRequestCreated">
-              <gov-heading size="m" tag="h3">Create event request</gov-heading>
-              <gov-body>{{ updateRequestMessage }}</gov-body>
-              <gov-back-link :to="{ name: 'events-index' }"
-                >Back to events</gov-back-link
-              >
-            </div>
+          <template v-if="updateRequestCreated">
+            <gov-heading size="m" tag="h3">Create event request</gov-heading>
+            <gov-body>{{ updateRequestMessage }}</gov-body>
+            <gov-back-link :to="{ name: 'events-index' }"
+              >Back to events</gov-back-link
+            >
           </template>
 
-          <template v-if="!updateRequestCreated">
+          <template v-else>
+            <div v-if="!auth.isGlobalAdmin">
+              <gov-body class="govuk-!-font-weight-bold">
+                Please review the process below on how to create an event.
+              </gov-body>
+
+              <gov-list bullet>
+                <li>To create an event, fill in the form below.</li>
+                <li>
+                  The event won't be visible until an admin has reviewed it.
+                </li>
+                <li>
+                  If there are any issues upon review, an admin will get
+                  directly in touch with you.
+                </li>
+              </gov-list>
+            </div>
             <gov-heading size="m">Add event</gov-heading>
             <gov-body
               >The events will appear on their own page will be discoverable and


### PR DESCRIPTION
### Summary
https://app.shortcut.com/ayup-digital-ltd/story/2239/update-the-admin-ui-text-when-an-event-has-successfully-been-added

- Hide intro text on event create after update request created

### Development checklist
- [ ] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
