### PR TITLE
Hide slug field from org admins

### DIFF
--- a/src/views/organisations/forms/OrganisationForm.vue
+++ b/src/views/organisations/forms/OrganisationForm.vue
@@ -10,6 +10,7 @@
     />
 
     <ck-text-input
+      v-if="auth.isGlobalAdmin"
       :value="slug"
       @input="onInput('slug', $event)"
       id="slug"


### PR DESCRIPTION
### Summary
https://app.shortcut.com/ayup-digital-ltd/story/1532/bug-update-request-failed-due-to-duplicate-service-slug

- Prevent issue of org admins submitting a change to an org slug when they do not have permission to alter the org slug by hiding the org slug field from them

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
