### PR TITLE
Hide service delete warning if not allowed to delete

### DIFF
--- a/src/views/services/Show.vue
+++ b/src/views/services/Show.vue
@@ -36,12 +36,12 @@
             <router-view :service="service" />
           </gov-tabs>
 
-          <gov-body
-            >Please be certain of the action before deleting a
-            {{ service.type }}</gov-body
-          >
-
           <template v-if="auth.isGlobalAdmin">
+            <gov-body
+              >Please be certain of the action before deleting a
+              {{ service.type }}</gov-body
+            >
+
             <gov-section-break size="l" />
 
             <ck-delete-button


### PR DESCRIPTION
### Summary
https://app.shortcut.com/ayup-digital-ltd/story/2320/bug-can-t-delete-a-service

- Hide delete service warning if not Golbal Admin

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
