### PR TITLE
Changed limit on service intro field and added limit to event intro f…

### DIFF
--- a/src/views/events/forms/DetailsTab.vue
+++ b/src/views/events/forms/DetailsTab.vue
@@ -52,12 +52,12 @@
       :error="errors.get(['start_time', 'end_time'])"
     />
 
-    <ck-text-input
+    <ck-textarea-input
       :value="intro"
       @input="onInput('intro', $event)"
       id="intro"
       label="Event summary*"
-      type="text"
+      :maxlength="255"
       :error="errors.get('intro')"
     />
 

--- a/src/views/services/forms/DescriptionTab.vue
+++ b/src/views/services/forms/DescriptionTab.vue
@@ -19,7 +19,7 @@
           id="intro"
           :label="`Your ${type}, an overview?`"
           :hint="`Write a brief description of what your ${type} does.`"
-          :maxlength="300"
+          :maxlength="255"
           :error="errors.get('intro')"
         />
 


### PR DESCRIPTION
### Summary
https://app.shortcut.com/ayup-digital-ltd/story/2606/unable-to-approve-event-update-request

- Changed limit on service intro field to 255 chars
- Added 255 char limit to event intro field

### Development checklist
- [ ] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
